### PR TITLE
Scale rating automatically when serializing popularity/rating field

### DIFF
--- a/id3/id3v2frame.cpp
+++ b/id3/id3v2frame.cpp
@@ -719,7 +719,7 @@ Id3v2FrameMaker::Id3v2FrameMaker(Id3v2Frame &frame, std::uint8_t version, Diagno
             // make popularimeter frame
             auto popularity = Popularity();
             try {
-                popularity = values.front()->toPopularity();
+                popularity = values.front()->toScaledPopularity(TagType::Id3v2Tag);
             } catch (const ConversionException &) {
                 diag.emplace_back(DiagLevel::Warning,
                     argsToString(

--- a/tagvalue.h
+++ b/tagvalue.h
@@ -77,13 +77,15 @@ struct TAG_PARSER_EXPORT Popularity {
     /// \brief Play counter specific to the user.
     std::uint64_t playCounter = 0;
     /// \brief Specifies the scale used for \a rating by the tag defining that scale.
-    /// \remarks The value TagType::Unspecified is preserved to denote a generic scale is used (no
-    /// conversions to/from a generic scale to tag format specific scales have been implemented at
-    /// this point).
+    /// \remarks The value TagType::Unspecified is used to denote a *generic* scale from 1.0 to
+    ///          5.0 where 5.0 is the best and the special value 0.0 stands for "not rated".
     TagType scale = TagType::Unspecified;
 
+    bool scaleTo(TagType targetScale);
+    Popularity scaled(TagType targetScale) const;
     std::string toString() const;
     static Popularity fromString(std::string_view str);
+    static Popularity fromString(std::string_view str, TagType scale);
 
     /// \brief Returns whether the Popularity is empty. The \a scale and zero-values don't count.
     bool isEmpty() const
@@ -100,6 +102,16 @@ struct TAG_PARSER_EXPORT Popularity {
         return playCounter == other.playCounter && rating == other.rating && user == other.user && scale == other.scale;
     }
 };
+
+/*!
+ * \brief Same as Popularity::scaleTo() but returns a new object.
+ */
+inline Popularity Popularity::scaled(TagType targetScale) const
+{
+    auto copy = *this;
+    copy.scaleTo(targetScale);
+    return copy;
+}
 
 /*!
  * \brief Specifies the data type.
@@ -179,6 +191,7 @@ public:
     CppUtilities::TimeSpan toTimeSpan() const;
     CppUtilities::DateTime toDateTime() const;
     Popularity toPopularity() const;
+    Popularity toScaledPopularity(TagType scale = TagType::Unspecified) const;
     std::size_t dataSize() const;
     char *dataPointer();
     const char *dataPointer() const;

--- a/vorbis/vorbiscommentfield.cpp
+++ b/vorbis/vorbiscommentfield.cpp
@@ -104,6 +104,7 @@ template <class StreamType> void VorbisCommentField::internalParse(StreamType &s
                     } catch (const ConversionException &) {
                         // fallback to text
                         value().assignText(str, TagTextEncoding::Utf8);
+                        diag.emplace_back(DiagLevel::Warning, argsToString("The rating is not a number."), context);
                     }
                 } else {
                     // extract other values (as string)
@@ -210,6 +211,8 @@ bool VorbisCommentField::make(BinaryWriter &writer, VorbisCommentFlags flags, Di
                     argsToString("An IO error occurred when writing the METADATA_BLOCK_PICTURE struct: ", failure.what()), context);
                 throw Failure();
             }
+        } else if (value().type() == TagDataType::Popularity) {
+            valueString = value().toScaledPopularity(TagType::VorbisComment).toString();
         } else {
             // make normal string value
             valueString = value().toString();


### PR DESCRIPTION
* Allow one to get a `Popularity` where `.rating` is always between 1 and 5
  via `TagValue::toScaledPopularity()` (or a "raw" scale by specifying the
  corresponding tag format)
* Allow one to assign a `Popularity` with `.scale = TagType::Unspecified`
  and `.rating` between 1 and 5 (or a "raw" scale by specifying the
  corresponding tag format). It will then be converted internally to
  the required scale (whatever the tag format internally uses)
    * Ensure all tag formats with popularity/rating field use
      `TagValue::toScaledPopularity()` internally when a `Popularity`
      object is assigned
* Ensure all tag formats with popularity/rating field store the rating as
  popularity object to preserve the scaling information
* Keep passing raw strings around working
    * `TagValue::toString()` still does *no* scaling
    * `TagValue::toScaledPopularity()` does *no* scaling for text values
      and instead just assigns the specified scale
* See https://github.com/Martchus/tagparser/issues/23